### PR TITLE
Remove Bookmark Duplicates script

### DIFF
--- a/db/migrate/20251212054437_add_unique_index_to_bookmarks_url.rb
+++ b/db/migrate/20251212054437_add_unique_index_to_bookmarks_url.rb
@@ -1,5 +1,0 @@
-class AddUniqueIndexToBookmarksUrl < ActiveRecord::Migration[8.1]
-  def change
-    add_index :bookmarks, [ :url, :user_id ], unique: true
-  end
-end

--- a/db/migrate/20251217135527_remove_unique_index_from_bookmarks_url.rb
+++ b/db/migrate/20251217135527_remove_unique_index_from_bookmarks_url.rb
@@ -1,5 +1,5 @@
 # Temporarily remove the index if it exists. Need to remove duplicates first using maintenance:duplicate_urls script
-class RemoveUniqueIndexToBookmarksUrl < ActiveRecord::Migration[8.1]
+class RemoveUniqueIndexFromBookmarksUrl < ActiveRecord::Migration[8.1]
   def change
     if index_exists? :bookmarks, [ :url, :user_id ], unique: true
       remove_index :bookmarks, [ :url, :user_id ], unique: true

--- a/db/migrate/20251217135527_remove_unique_index_to_bookmarks_url.rb
+++ b/db/migrate/20251217135527_remove_unique_index_to_bookmarks_url.rb
@@ -1,0 +1,8 @@
+# Temporarily remove the index if it exists. Need to remove duplicates first using maintenance:duplicate_urls script
+class RemoveUniqueIndexToBookmarksUrl < ActiveRecord::Migration[8.1]
+  def change
+    if index_exists? :bookmarks, [ :url, :user_id ], unique: true
+      remove_index :bookmarks, [ :url, :user_id ], unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_12_12_054437) do
+ActiveRecord::Schema[8.1].define(version: 2025_12_17_135527) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -47,7 +47,6 @@ ActiveRecord::Schema[8.1].define(version: 2025_12_12_054437) do
     t.datetime "updated_at", null: false
     t.string "url", null: false
     t.integer "user_id", null: false
-    t.index ["url", "user_id"], name: "index_bookmarks_on_url_and_user_id", unique: true
     t.index ["user_id"], name: "index_bookmarks_on_user_id"
   end
 

--- a/lib/tasks/maintenance/duplicate_urls.rake
+++ b/lib/tasks/maintenance/duplicate_urls.rake
@@ -68,7 +68,7 @@ namespace :maintenance do
             # Delete the duplicate
             duplicate.destroy
             total_deleted += 1
-            puts "  ✅ Deleted duplicate ID=#{duplicate.id}"
+            puts "  ✅ Deleted duplicate ID=#{duplicate.id} kept ID=#{keeper.id}"
           else
             puts "  ❌ Failed to save merged bookmark: #{keeper.errors.full_messages.join(', ')}"
           end

--- a/lib/tasks/maintenance/duplicate_urls.rake
+++ b/lib/tasks/maintenance/duplicate_urls.rake
@@ -1,7 +1,10 @@
 namespace :maintenance do
-  desc "Find and merge duplicate bookmark URLs per user"
+  desc "Find and merge duplicate bookmark URLs per user (set DRY_RUN=true to preview without deleting)"
   task duplicate_urls: :environment do
+    dry_run = ENV["DRY_RUN"] == "true"
+
     puts "Starting duplicate URL cleanup..."
+    puts "DRY RUN MODE: No changes will be saved" if dry_run
     puts "=" * 80
 
     total_duplicates = 0
@@ -25,54 +28,56 @@ namespace :maintenance do
       puts "  Found #{duplicate_urls.size} duplicate URL(s)"
 
       duplicate_urls.each do |url|
-        # Get all bookmarks with this URL, ordered by created_at (oldest first)
-        bookmarks = user.bookmarks.where(url: url).order(created_at: :asc).to_a
+        ActiveRecord::Base.transaction do
+          # Get all bookmarks with this URL, ordered by created_at (oldest first)
+          bookmarks = user.bookmarks.where(url: url).order(created_at: :asc).to_a
 
-        # Keep the oldest, merge data from newer ones
-        keeper = bookmarks.first
-        duplicates = bookmarks[1..]
+          # Keep the oldest, merge data from newer ones
+          keeper = bookmarks.first
+          duplicates = bookmarks[1..]
 
-        puts "\n  Processing duplicates for: #{url}"
-        puts "  Keeper (oldest): ID=#{keeper.id}, Title='#{keeper.title}', Created=#{keeper.created_at}"
+          puts "\n  Processing duplicates for: #{url}"
+          puts "  Keeper (oldest): ID=#{keeper.id}, Title='#{keeper.title}', Created=#{keeper.created_at}"
 
         duplicates.each do |duplicate|
           puts "  Duplicate: ID=#{duplicate.id}, Title='#{duplicate.title}', Created=#{duplicate.created_at}"
           total_duplicates += 1
-
-          # Merge tags (combine unique tags from both)
-          original_tags = keeper.tags.pluck(:name)
-          duplicate_tags = duplicate.tags.pluck(:name)
-          merged_tags = (original_tags + duplicate_tags).uniq
 
           # Prefer newer bookmark's data for certain fields
           keeper.title = duplicate.title if duplicate.title.present?
           keeper.description = duplicate.description if duplicate.description.present?
           keeper.feed_url = duplicate.feed_url if duplicate.feed_url.present?
 
-          # Merge tags
+          # Merge tags (combine unique tags from both)
+          original_tags = keeper.tags.pluck(:name)
+          duplicate_tags = duplicate.tags.pluck(:name)
+          merged_tags = (original_tags + duplicate_tags).uniq
+
           keeper.tags = merged_tags.map { |name| user.tags.find_or_create_by(name: name.downcase) }
 
-          # Transfer icons if keeper doesn't have them but duplicate does
-          if !keeper.icon.attached? && duplicate.icon.attached?
-            keeper.icon.attach(duplicate.icon.blob)
-          end
+          # Do not transfer icons to avoid complexity
 
-          if !keeper.apple_touch_icon.attached? && duplicate.apple_touch_icon.attached?
-            keeper.apple_touch_icon.attach(duplicate.apple_touch_icon.blob)
-          end
-
-          # Save the merged keeper
-          if keeper.save
-            puts "  Merged result: ID=#{keeper.id}, Title='#{keeper.title}', Tags=[#{keeper.tag_list}]"
-
-            # Delete the duplicate
-            duplicate.destroy
-            total_deleted += 1
-            puts "  ✅ Deleted duplicate ID=#{duplicate.id} kept ID=#{keeper.id}"
+          if dry_run
+            puts "  Merged result: ID=#{keeper.id}, Title='#{keeper.title}', Tags=[#{merged_tags.join(', ')}]"
+            puts "  🔍 [DRY RUN] Would delete duplicate ID=#{duplicate.id}, keeping ID=#{keeper.id}"
           else
-            puts "  ❌ Failed to save merged bookmark: #{keeper.errors.full_messages.join(', ')}"
+            # Save the merged keeper
+            if keeper.save
+              puts "  Merged result: ID=#{keeper.id}, Title='#{keeper.title}', Tags=[#{keeper.tag_list}]"
+
+              # Delete the duplicate
+              duplicate.destroy
+              total_deleted += 1
+              puts "  ✅ Deleted duplicate ID=#{duplicate.id} kept ID=#{keeper.id}"
+            else
+              puts "  ❌ Failed to save merged bookmark: #{keeper.errors.full_messages.join(', ')}"
+            end
           end
         end
+
+        # Rollback transaction if in dry-run mode
+        raise ActiveRecord::Rollback if dry_run
+      end
       end
     end
 

--- a/lib/tasks/maintenance/duplicate_urls.rake
+++ b/lib/tasks/maintenance/duplicate_urls.rake
@@ -1,0 +1,84 @@
+namespace :maintenance do
+  desc "Find and merge duplicate bookmark URLs per user"
+  task duplicate_urls: :environment do
+    puts "Starting duplicate URL cleanup..."
+    puts "=" * 80
+
+    total_duplicates = 0
+    total_deleted = 0
+
+    User.find_each do |user|
+      puts "\nProcessing user: ID: #{user.id}"
+
+      # Find duplicate URLs for this user
+      duplicate_urls = user.bookmarks
+        .group(:url)
+        .having("COUNT(*) > 1")
+        .count
+        .keys
+
+      if duplicate_urls.empty?
+        puts "  No duplicates found"
+        next
+      end
+
+      puts "  Found #{duplicate_urls.size} duplicate URL(s)"
+
+      duplicate_urls.each do |url|
+        # Get all bookmarks with this URL, ordered by created_at (oldest first)
+        bookmarks = user.bookmarks.where(url: url).order(created_at: :asc).to_a
+
+        # Keep the oldest, merge data from newer ones
+        keeper = bookmarks.first
+        duplicates = bookmarks[1..]
+
+        puts "\n  Processing duplicates for: #{url}"
+        puts "  Keeper (oldest): ID=#{keeper.id}, Title='#{keeper.title}', Created=#{keeper.created_at}"
+
+        duplicates.each do |duplicate|
+          puts "  Duplicate: ID=#{duplicate.id}, Title='#{duplicate.title}', Created=#{duplicate.created_at}"
+          total_duplicates += 1
+
+          # Merge tags (combine unique tags from both)
+          original_tags = keeper.tags.pluck(:name)
+          duplicate_tags = duplicate.tags.pluck(:name)
+          merged_tags = (original_tags + duplicate_tags).uniq
+
+          # Prefer newer bookmark's data for certain fields
+          keeper.title = duplicate.title if duplicate.title.present?
+          keeper.description = duplicate.description if duplicate.description.present?
+          keeper.feed_url = duplicate.feed_url if duplicate.feed_url.present?
+
+          # Merge tags
+          keeper.tags = merged_tags.map { |name| user.tags.find_or_create_by(name: name.downcase) }
+
+          # Transfer icons if keeper doesn't have them but duplicate does
+          if !keeper.icon.attached? && duplicate.icon.attached?
+            keeper.icon.attach(duplicate.icon.blob)
+          end
+
+          if !keeper.apple_touch_icon.attached? && duplicate.apple_touch_icon.attached?
+            keeper.apple_touch_icon.attach(duplicate.apple_touch_icon.blob)
+          end
+
+          # Save the merged keeper
+          if keeper.save
+            puts "  Merged result: ID=#{keeper.id}, Title='#{keeper.title}', Tags=[#{keeper.tag_list}]"
+
+            # Delete the duplicate
+            duplicate.destroy
+            total_deleted += 1
+            puts "  ✅ Deleted duplicate ID=#{duplicate.id}"
+          else
+            puts "  ❌ Failed to save merged bookmark: #{keeper.errors.full_messages.join(', ')}"
+          end
+        end
+      end
+    end
+
+    puts "\n" + "=" * 80
+    puts "Cleanup complete!"
+    puts "Total duplicate bookmarks found: #{total_duplicates}"
+    puts "Total bookmarks deleted: #{total_deleted}"
+  end
+end


### PR DESCRIPTION
Before I can add an index to the Bookmarks table I need to clean the duplicates first.
This will undo the index if it exists (it shouldn't) and then I can run the Rake script to remove the dups.
Then in the future we can re-add the index on `bookmarks(user_id,url)` if we so desire.