### PR TITLE
Implement Click Tracking

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -1,6 +1,7 @@
 require "net/http"
 
 class BookmarksController < ApplicationController
+  skip_before_action :verify_authenticity_token, only: :ping
   before_action :set_bookmark, only: %i[ show edit update destroy ]
 
   # GET /bookmarks or /bookmarks.json
@@ -98,6 +99,11 @@ class BookmarksController < ApplicationController
       Rails.logger.error("Error fetching title for URL #{url}: #{e.message}")
       render json: { error: "Error fetching title", url: url }, status: :unprocessable_content
     end
+  end
+
+  def ping
+    Rails.logger.debug("Received ping request for User##{Current.user.id} with params: #{params.inspect}")
+    render plain: "OK", status: :ok
   end
 
   private

--- a/app/views/bookmarks/_bookmark_icon.html.erb
+++ b/app/views/bookmarks/_bookmark_icon.html.erb
@@ -1,4 +1,4 @@
-<a href="<%= bookmark.url %>" target="_blank" rel="noopener noreferrer" class="text-baby-powder-50 hover:underline">
+<a href="<%= bookmark.url %>" ping="<%= bookmark_ping_path(bookmark) %>" target="_blank" rel="noopener noreferrer" class="text-baby-powder-50 hover:underline">
   <%= favicon_image_tag(bookmark, class: "mx-auto size-12 md:size-24 rounded-[1vw] outline-1 -outline-offset-1 outline-black/5 dark:outline-bright-turquoise-300/10") %>
   <p class="mt-3 text-base/7 font-pt-sans-narrow font-semibold tracking-tight"><%= bookmark.title %></p>
 </a>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
     collection do
       get :fetch_remote_bookmark
     end
+    post :ping
   end
 
   # Bookmark import routes


### PR DESCRIPTION
This PR adds a ping attribute to links along with an endpoint to track links.
The `ping` attribute is not supported on Firefox and can easily be blocked by browsers - but its fun to add.
